### PR TITLE
Add: lint rule for max-len exceptions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,12 +16,6 @@
     "dot-notation": "error",
     "eol-last": "error",
     "eqeqeq": "error",
-    "function-paren-newline": [
-      "error",
-      {
-        "minItems": 4
-      }
-    ],
     "indent": ["error", 2],
     "key-spacing": [
       "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,10 @@
     "max-len": [
       "error",
       {
-        "code": 80
+        "code": 80,
+        "ignoreUrls": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true
       }
     ],
     "no-duplicate-imports": "error",


### PR DESCRIPTION
회의 때 논의된대로 string, url, template literal에 대해 예외를 추가했습니다.
프로젝트 컨벤션과 충돌이 일어나는 function-paren-newline 옵션을 삭제했습니다.