### PR TITLE
Add: ContentBoard component (separated from modal)

### DIFF
--- a/src/components/ContentBoard.jsx
+++ b/src/components/ContentBoard.jsx
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 
 import theme from "../theme";
 
+const SIZE_UNIT = "px";
+
 const Outer = styled.div`
   display: flex;
   flex-direction: column;
@@ -11,8 +13,8 @@ const Outer = styled.div`
   box-sizing: border-box;
   box-shadow: 5px 5px 10px ${({ theme }) => theme.greyScaleColors.darkGrey};
   background-color: ${(props) => props.backgroundColor};
-  width: ${(props) => props.widthSize};
-  height: ${(props) => props.heightSize};
+  width: ${(props) => String(props.widthSize) + SIZE_UNIT};
+  height: ${(props) => String(props.heightSize) + SIZE_UNIT};
   border-radius: 10px;
   padding: 25px 20px 20px 20px;
 `;
@@ -58,18 +60,18 @@ function ContentBoard({
 
 ContentBoard.propTypes = {
   text: PropTypes.string.isRequired,
-  backgroundColor: PropTypes.string,
+  backgroundColor: PropTypes.oneOf(theme.background),
   heading: PropTypes.string,
-  width: PropTypes.string,
-  height: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
   children: PropTypes.element,
 };
 
 ContentBoard.defaultProps = {
-  backgroundColor: theme.pinkColors.lightPink,
+  backgroundColor: theme.background.main,
   heading: "",
-  width: "480px",
-  height: "360px",
+  width: 480,
+  height: 360,
 };
 
 export default ContentBoard;

--- a/src/components/ContentBoard.jsx
+++ b/src/components/ContentBoard.jsx
@@ -5,22 +5,24 @@ import PropTypes from "prop-types";
 import theme from "../theme";
 
 const Outer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
   box-sizing: border-box;
   box-shadow: 5px 5px 10px ${({ theme }) => theme.greyScaleColors.darkGrey};
   background-color: ${(props) => props.backgroundColor};
-  width: -webkit-fit-content;
-  height: -webkit-fit-content;
+  width: ${(props) => props.widthSize};
+  height: ${(props) => props.heightSize};
   border-radius: 10px;
   padding: 25px 20px 20px 20px;
 `;
 
 const Inner = styled.div`
+  flex-direction: row;
+  flex-grow: 1;
   box-sizing: border-box;
   background-color: ${({ theme }) => theme.greyScaleColors.fadeWhite};
   border-radius: 10px;
-  width: ${(props) => props.widthSize};
-  height: ${(props) => props.heightSize};
-  margin: auto;
   padding: 20px;
   font-size: 1.2rem;
 `;
@@ -40,9 +42,13 @@ function ContentBoard({
   children,
 }) {
   return (
-    <Outer backgroundColor={backgroundColor}>
+    <Outer
+      widthSize={width}
+      heightSize={height}
+      backgroundColor={backgroundColor}
+    >
       {heading && <Heading>{heading}</Heading>}
-      <Inner widthSize={width} heightSize={height}>
+      <Inner>
         {text}
       </Inner>
       {children}

--- a/src/components/ContentBoard.jsx
+++ b/src/components/ContentBoard.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+import theme from "../theme";
+
+const Outer = styled.div`
+  box-sizing: border-box;
+  box-shadow: 5px 5px 10px ${({ theme }) => theme.greyScaleColors.darkGrey};
+  background-color: ${(props) => props.backgroundColor};
+  width: -webkit-fit-content;
+  height: -webkit-fit-content;
+  border-radius: 10px;
+  padding: 25px 20px 20px 20px;
+`;
+
+const Inner = styled.div`
+  box-sizing: border-box;
+  background-color: ${({ theme }) => theme.greyScaleColors.fadeWhite};
+  border-radius: 10px;
+  width: ${(props) => props.widthSize};
+  height: ${(props) => props.heightSize};
+  margin: auto;
+  padding: 20px;
+  font-size: 1.2rem;
+`;
+
+const Heading = styled.p`
+  margin: 0 0 10px 0;
+  color: ${({ theme }) => theme.greyScaleColors.fadeWhite};
+  font-size: 1.5rem;
+`;
+
+function ContentBoard({
+  backgroundColor,
+  width,
+  height,
+  heading,
+  text,
+  children,
+}) {
+  return (
+    <Outer backgroundColor={backgroundColor}>
+      {heading && <Heading>{heading}</Heading>}
+      <Inner widthSize={width} heightSize={height}>
+        {text}
+      </Inner>
+      {children}
+    </Outer>
+  );
+}
+
+ContentBoard.propTypes = {
+  text: PropTypes.string.isRequired,
+  backgroundColor: PropTypes.string,
+  heading: PropTypes.string,
+  width: PropTypes.string,
+  height: PropTypes.string,
+  children: PropTypes.element,
+};
+
+ContentBoard.defaultProps = {
+  backgroundColor: theme.pinkColors.lightPink,
+  heading: "",
+  width: "480px",
+  height: "360px",
+};
+
+export default ContentBoard;

--- a/src/components/modalComponent.jsx
+++ b/src/components/modalComponent.jsx
@@ -1,45 +1,24 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
+import ContentBoard from "./ContentBoard";
 import Button from "./Button";
-import SIZE from "../constants/numbers";
 
 const ModalWrapper = styled.div`
   position: fixed;
+  display: flex;
   background-color: rgba(0, 0, 0, 0.8);
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
   z-index: 1;
+  justify-content: center;
+  align-items: center;
 `;
 
-const OuterModal = styled.div`
-  position: absolute;
-  box-sizing: border-box;
-  box-shadow: 5px 5px 10px black;
-  background-color: ${( props ) => props.backgroundColor
-    ? props.backgroundColor : props.theme.pinkColors.lightPink};
-  border-radius: 10px;
-  top: 20vh;
-  left: 30vw;
-  width: ${(props) => props.width
-    ? props.width : "520px"};
-  height: 480px;
-  padding: 40px 20px;
-  margin: -50px;
-`;
-
-const InnerModal = styled.div`
-  position: relative;
-  box-sizing: border-box;
-  background-color: ${(props) => props.theme.greyScaleColors.fadeWhite};
-  border-radius: 10px;
-  width: ${(props) => props.width * SIZE.RATIO.MODAL
-    ? props.width * SIZE.RATIO.MODAL : "480px"};
-  height: 360px;
-  margin: auto;
-  padding: 40px 20px;
+const BoardWrapper = styled.div`
+  margin-top: -50px;
 `;
 
 const ButtonWrapper = styled.div`
@@ -60,27 +39,26 @@ function ModalComponent({
   return (
     <form>
       <ModalWrapper>
-        <OuterModal backgroundColor={backgroundColor}>
-          <InnerModal>
-            {innerText}
-          </InnerModal>
-          <ButtonWrapper>
-            <Button
-              onClick={onConfirm}
-              buttonText={confirmText}
-              backgroundColor={backgroundColor}
-              width={width}
-              height={height}
-            />
-            <Button
-              onClick={onCancel}
-              buttonText={cancelText}
-              backgroundColor={backgroundColor}
-              width={width}
-              height={height}
-            />
-          </ButtonWrapper>
-        </OuterModal>
+        <BoardWrapper>
+          <ContentBoard backgroundColor={backgroundColor} text={innerText}>
+            <ButtonWrapper>
+              <Button
+                onClick={onConfirm}
+                buttonText={confirmText}
+                backgroundColor={backgroundColor}
+                width={width}
+                height={height}
+              />
+              <Button
+                onClick={onCancel}
+                buttonText={cancelText}
+                backgroundColor={backgroundColor}
+                width={width}
+                height={height}
+              />
+            </ButtonWrapper>
+          </ContentBoard>
+        </BoardWrapper>
       </ModalWrapper>
     </form>
   );

--- a/src/components/modalComponent.jsx
+++ b/src/components/modalComponent.jsx
@@ -7,7 +7,7 @@ import Button from "./Button";
 const ModalWrapper = styled.div`
   position: fixed;
   display: flex;
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: ${({ theme }) => theme.background.modal};
   top: 0;
   left: 0;
   right: 0;

--- a/src/constants/numbers.js
+++ b/src/constants/numbers.js
@@ -14,14 +14,9 @@ const TEXT = {
   TITLE: 100,
 };
 
-const RATIO = {
-  MODAL: 0.92,
-};
-
 const SIZE = {
   TEXT,
   GAP,
-  RATIO,
 };
 
 export default SIZE;

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -35,12 +35,19 @@ const greyScaleColors = {
   fadeLightGrey: "E6F5F6F6",
 };
 
+const background = {
+  main: pinkColors.lightPink,
+  sub: mintColors.mainMint,
+  modal: "rgba(0, 0, 0, 0.8)",
+};
+
 const theme = {
   gaps,
   fontSizes,
   pinkColors,
   mintColors,
   greyScaleColors,
+  background,
 };
 
 export default theme;


### PR DESCRIPTION
- 기존의 modalComponent에서 컨텐츠가 들어가는 부분만 분리한 컴포넌트 입니다.
- sleep과 activity 페이지에서 공유하기 위해 해당 컴포넌트만 우선 PR 생성하였습니다.
- 사이즈를 동적으로 변경하기 위해, prop으로 받고 Inner는 Outer에 맞춰 조정되도록 변경하여 사이즈 계산 로직과 관련 변수는 삭제하였습니다.

![image](https://user-images.githubusercontent.com/60309558/132541483-ca397f6e-4bb5-418c-a1b9-d7bd37f7e362.png)
