### PR TITLE
Fix: router path Error, undefined TypeError

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,34 +64,35 @@ function App() {
                 <Route path="/login">
                   <Login />
                 </Route>
-                <PrivateRoute path="/:creatorId/condition">
+                <PrivateRoute exact path="/:creatorId/condition">
                   <Condition />
                 </PrivateRoute>
-                <PrivateRoute path="/:creatorId/friend">
+                <PrivateRoute exact path="/:creatorId/friend">
                   <Friend />
                 </PrivateRoute>
-                <PrivateRoute path="/:creatorId/meal">
+                <PrivateRoute exact path="/:creatorId/meal">
                   <Meal />
                 </PrivateRoute>
-                <PrivateRoute path="/:creatorId/activity">
+                <PrivateRoute exact path="/:creatorId/activity">
                   <Activity />
                 </PrivateRoute>
-                <PrivateRoute path="/:creatorId/sleep">
+                <PrivateRoute exact path="/:creatorId/sleep">
                   <p>Sleep</p>
                 </PrivateRoute>
-                <PrivateRoute path="/:creatorId/:category">
+                <PrivateRoute exact path="/:creatorId/:category">
                   <CustomCategory />
                 </PrivateRoute>
-                <PrivateRoute path="/:creatorId/friend/:friendId">
+                <PrivateRoute exact path="/:creatorId/friend/:friendId">
                   <FriendDetail />
                 </PrivateRoute>
+                <Route path="/:creatorId/:category/:ratingId">
+                  <Detail />
+                </Route>
                 <Route path="*">
                   <p>Not Found</p>
                 </Route>
               </Switch>
-              <Route path="/:creatorId/:category/:ratingId">
-                <Detail />
-              </Route>
+
             </PageWrapper>
           </>
         ) : (

--- a/src/components/CommentViewer.jsx
+++ b/src/components/CommentViewer.jsx
@@ -20,6 +20,10 @@ function CommentViewer({
   const user = useSelector((state) => state.user);
   const isCreator = user.id === creatorId;
 
+  if (!comments) {
+    return null;
+  }
+
   return (
     <Wrapper>
       {comments.map((comment) => (

--- a/src/pages/CustomCategory.jsx
+++ b/src/pages/CustomCategory.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { useParams } from "react-router-dom";
 
 import CustomAlbum from "./CustomAlbum";
@@ -11,6 +11,7 @@ import { ERROR } from "../constants/messages";
 function CustomCategory() {
   const { customCategories } = useSelector((state) => state.user);
   const { category: categoryName } = useParams();
+  const dispatch = useDispatch();
 
   const categoryInfo = customCategories
     .find(({ category }) => category === categoryName);
@@ -19,7 +20,9 @@ function CustomCategory() {
     const statusCode = STATUS_CODES.NOT_FOUND;
     const message = ERROR.NOT_FOUND;
 
-    setError({ statusCode, message });
+    dispatch(setError({ statusCode, message }));
+
+    return null;
   }
 
   const { categoryType } = categoryInfo;

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -119,7 +119,7 @@ function Detail() {
   );
 
   if (!data) {
-    return <p>Loading...</p>;
+    return null;
   }
 
   const type = data.category ? data.category : data.type;

--- a/src/pages/FriendDetail.js
+++ b/src/pages/FriendDetail.js
@@ -108,7 +108,7 @@ function FriendDetail() {
   );
 
   if (!records) {
-    return <p>Loading...</p>;
+    return null;
   }
 
   const recordBars = records.map((record) => <ContentBar

--- a/src/pages/Meal.jsx
+++ b/src/pages/Meal.jsx
@@ -76,6 +76,10 @@ function Meal() {
     loadMeals(nextPage);
   };
 
+  if (!meals) {
+    return null;
+  }
+
   const mealBars = (meals.length) ? meals.map((meal) => {
     return (
       <Link to={`/${creatorId}/meal/${meal._id}`} key={meal._id}>


### PR DESCRIPTION
 -  [a61f2c5] 아래 이슈 해결을 위해 Switch문들에 exact를 추가하였습니다.
https://www.notion.so/vanillacoding/404-a517a9e2b27a4848ba47ac8e32e7da15
`<PrivateRoute exact path="/:creatorId/meal">` -> 유효하지 않은 id는 접근불가
![image](https://user-images.githubusercontent.com/60309558/133378662-aed8963e-ae54-4b60-a895-29607309795a.png)
`<PrivateRoute path="/:creatorId/meal">` -> 유효하지 않은 id는 무시되고 에러 팝업 없이 상위 라우터에서 처리
![image](https://user-images.githubusercontent.com/60309558/133378804-2a3fc285-58c6-4192-8dcc-4e209074cb62.png)

- [588dd1f] 잘못된 경로로 접근한 경우, api 요청에서 undefined를 반환해 처리할 데이터가 없는 경우에 null을 반환하도록 설정했습니다. 
![Screen Shot 2021-09-15 at 2 13 18 PM](https://user-images.githubusercontent.com/60309558/133379146-236e47d7-28a6-441d-96f1-716069fdf318.png)
![Screen Shot 2021-09-15 at 2 18 09 PM](https://user-images.githubusercontent.com/60309558/133379281-700be7b7-45e2-4489-993e-122e6903c88e.png)

