### PR TITLE
Fix: no sleep data error

### DIFF
--- a/src/pages/Sleep.jsx
+++ b/src/pages/Sleep.jsx
@@ -38,7 +38,7 @@ function Sleep() {
   }, []);
 
   useEffect(() => {
-    if (sleepData) {
+    if (sleepData?.length) {
       setPeriods(`${sleepData[0]._id} ~ ${ sleepData[sleepData.length - 1]._id} `);
     }
   }, [sleepData]);


### PR DESCRIPTION
빈 배열일 때 0번째 요소의 _id 속성에 접근해서 생기는 오류로 확인되었습니다.
sleepData의 length 값이 참일 때만 업데이트하도록 수정했습니다.
closes #119 