### PR TITLE
Fix: dispatch logout in App when refresh is expired (issue 122)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,9 +20,9 @@ import FriendDetail from "./pages/FriendDetail";
 import Login from "./components/Login";
 import PrivateRoute from "./components/PrivateRoute";
 import Loading from "./components/Loading";
-import { setUserInfos } from "./features/userSlice";
+import { setUserInfos, logout } from "./features/userSlice";
 import { getUserInfos } from "./api/auth";
-import { checkTokenExist } from "./helpers/userInfo";
+import { checkTokenValid } from "./helpers/userInfo";
 import MenuBar from "./components/MenuBar";
 
 const AppWrapper = styled.div`
@@ -64,9 +64,10 @@ function App() {
       setIsLoaded(true);
     }
 
-    if (checkTokenExist()) {
+    if (checkTokenValid()) {
       dispatchUserInfos();
     } else {
+      dispatch(logout());
       setIsLoaded(true);
     }
   }, []);

--- a/src/api/axiosInstance.js
+++ b/src/api/axiosInstance.js
@@ -3,7 +3,7 @@ import { store } from "../app/store";
 import { ERROR } from "../constants/messages";
 import STATUS_CODES from "../constants/statusCodes";
 import { setError } from "../features/errorSlice";
-import { getTokens, updateAccessToken } from "../helpers/userInfo";
+import { getTokens, checkExpired, updateAccessToken } from "../helpers/userInfo";
 
 async function setAccessToken(config) {
   const { accessToken, accessTokenExp } = getTokens();
@@ -12,9 +12,7 @@ async function setAccessToken(config) {
     throw new axios.Cancel(ERROR.ACCESS_TOKEN_NOT_EXIST);
   }
 
-  const oneSecondInMill = 1000;
-  const isExpired = Number(accessTokenExp) < (Date.now() / oneSecondInMill);
-
+  const isExpired = checkExpired(accessTokenExp);
   let token = accessToken;
 
   if (isExpired) {

--- a/src/helpers/userInfo.js
+++ b/src/helpers/userInfo.js
@@ -3,11 +3,17 @@ import { postRefresh } from "../api/auth";
 const REFRESH_TOKEN = "refreshToken";
 const REFRESH_EXPIRED_AT = "refreshToken-expiredAt";
 const ACCESS_TOKEN = "accessToken";
-const ACCESS_TOKEN_EXPIRED_AT = "accessToken-expiredAt";
+const ACCESS_EXPIRED_AT = "accessToken-expiredAt";
+
+function checkExpired(exp) {
+  const ONE_SECOND_IN_MILL = 1000;
+
+  return exp < (Date.now() / ONE_SECOND_IN_MILL);
+}
 
 function storeUserInfos({ accessToken, refreshToken }) {
   localStorage.setItem(ACCESS_TOKEN, accessToken.token);
-  localStorage.setItem(ACCESS_TOKEN_EXPIRED_AT, accessToken.exp);
+  localStorage.setItem(ACCESS_EXPIRED_AT, accessToken.exp);
   localStorage.setItem(REFRESH_TOKEN, refreshToken.token);
   localStorage.setItem(REFRESH_EXPIRED_AT, refreshToken.exp);
 }
@@ -19,14 +25,20 @@ function removeUserInfos() {
 function getTokens() {
   return {
     accessToken: localStorage.getItem(ACCESS_TOKEN),
-    accessTokenExp: localStorage.getItem(ACCESS_TOKEN_EXPIRED_AT),
+    accessTokenExp: Number(localStorage.getItem(ACCESS_EXPIRED_AT)),
     refreshToken: localStorage.getItem(REFRESH_TOKEN),
-    refreshTokenExp: localStorage.getItem(REFRESH_EXPIRED_AT),
+    refreshTokenExp: Number(localStorage.getItem(REFRESH_EXPIRED_AT)),
   };
 }
 
-function checkTokenExist() {
-  return !!localStorage.getItem(ACCESS_TOKEN);
+function checkTokenValid() {
+  const {
+    accessToken, accessTokenExp, refreshToken, refreshTokenExp,
+  } = getTokens();
+  const isAccessValid = !!accessToken && !checkExpired(accessTokenExp);
+  const isRefreshValid = !!refreshToken && !checkExpired(refreshTokenExp);
+
+  return isAccessValid || isRefreshValid;
 }
 
 async function updateAccessToken() {
@@ -34,13 +46,14 @@ async function updateAccessToken() {
   const accessToken = await postRefresh(refreshToken);
 
   localStorage.setItem(ACCESS_TOKEN, accessToken.token);
-  localStorage.setItem(ACCESS_TOKEN_EXPIRED_AT, accessToken.exp);
+  localStorage.setItem(ACCESS_EXPIRED_AT, accessToken.exp);
 }
 
 export {
+  checkExpired,
   storeUserInfos,
   removeUserInfos,
   getTokens,
-  checkTokenExist,
+  checkTokenValid,
   updateAccessToken,
 };


### PR DESCRIPTION
closes #122 
refresh token의 유효기간(exp)이 만료된 경우에도 잔여 토큰이 삭제나 갱신되지 않아 계속 500 에러가 뜨고, localStorage를 직접 비워주어야 접근 가능했던 에러를 해결하였습니다.

### Before

https://user-images.githubusercontent.com/60309558/147401980-76c42c24-086b-4449-b793-1b1695ba54d2.mp4


refresh 토큰이 만료되어도 /refresh 요청으로 접근해 401 에러가 뜨는 기존 에러 케이스입니다.

### After

https://user-images.githubusercontent.com/60309558/147401977-b07aea14-bdad-4180-84a3-a1a774ae0b10.mp4


수정 이후 refresh 토큰이 만료된 경우, 먼저 logout 처리를 하기 때문에 /login 으로 접근 후 정상 이용 가능합니다.

위 영상은 테스트를 위해 토큰 만료기간을 access 2초, refresh 10초로 변경하고 촬영하였습니다. (서버의 config/tokenInfos.js)

위 수정사항 관련하여 checkTokenExist 명칭을 checkTokenValid로 변경하고, 만료여부도 체크하도록 수정하였습니다.
  - checkTokenValid 내에서는 accessToken, refreshToken 중 하나라도 유효하면 true를 반환합니다. refreshToken만 유효하면 accessToken은 axiosInterceptor에서 자동 갱신되기 때문입니다.
  - axiosInterceptor 내에 있던 토큰 만료 확인 로직을 helpers/userInfo 내 checkExpired로 이동하였습니다.
  - 관련해 getTokens의 exp 프로퍼티를 숫자로 변경하였습니다.
  - 유효기간 관련 변수명을 일관되게 수정하였습니다. (ACCESS_TOKEN_EXPIRED_AT -> ACCESS_EXPIRED_AT)