### PR TITLE
Fix: Condition에서 map의 콜백함수의 반환값을 fragment로 하여 key prop이 없는 경고가 뜨는 현상

### DIFF
--- a/src/pages/Condition.jsx
+++ b/src/pages/Condition.jsx
@@ -159,11 +159,11 @@ function Condition() {
     setIsRadarGraph(!isRadarGraph);
   };
 
-  const statusInfos = status ? Object.keys(status).map((category) => (
-    <>
-      <span key={category}>{category}</span>
-      <HeartCounter key={category + "status"} count={status[category]} />
-    </>
+  const statusInfos = status ? Object.keys(status).flatMap((category) => (
+    [
+      <span key={category}>{category}</span>,
+      <HeartCounter key={category + "status"} count={status[category]} />,
+    ]
   )) : [];
 
   return (


### PR DESCRIPTION
- 두 개의 요소를 부모 요소 없이 리스트에 넣기 위해 `Array.prototype.flatMap`을 사용하였습니다.